### PR TITLE
email notification after file upload

### DIFF
--- a/app/controllers/infdot_upload_controller.rb
+++ b/app/controllers/infdot_upload_controller.rb
@@ -82,6 +82,9 @@ class InfdotUploadController < ActionController::Base
     end
     
     if @errors.empty?
+      if Setting.notified_events.include?('file_added')
+        Mailer.attachments_added([a]).deliver
+      end
       render :json => Response.new(nil)
     else
       render :json => Response.new(@errors.join(" "))


### PR DESCRIPTION
Sending email notification if that type of notifications is selected in general settings.

[a] is used as mailer uses 

```
container = attachments.first.container
```
